### PR TITLE
Added 2 additional plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
         "wpbakery/pagebuilder": "5.4.7",
         "wpackagist-plugin/real-media-library-lite": "4.19.0",
         "wpackagist-plugin/advanced-cron-manager": "2.5.0",
-        "wpackagist-plugin/advanced-database-cleaner": "3.1.2"
+        "wpackagist-plugin/advanced-database-cleaner": "3.1.2",
+        "wpackagist-plugin/breeze": "2.0.20",
+        "wpackagist-plugin/classic-editor": "1.6.3"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48121e0b6b99220d2d3949168f638010",
+    "content-hash": "6909ef0d1cd0770d61baf452d81a0c6a",
     "packages": [
         {
             "name": "composer/installers",
@@ -218,6 +218,42 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/all-in-one-seo-pack/"
+        },
+        {
+            "name": "wpackagist-plugin/breeze",
+            "version": "2.0.20",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/breeze/",
+                "reference": "tags/2.0.20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/breeze.2.0.20.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/breeze/"
+        },
+        {
+            "name": "wpackagist-plugin/classic-editor",
+            "version": "1.6.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/classic-editor/",
+                "reference": "tags/1.6.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/classic-editor/"
         },
         {
             "name": "wpackagist-plugin/real-media-library-lite",


### PR DESCRIPTION
1) Breeze 2.0.20
2) Classic Editor 1.6.3

I wasn't able to find Classic Editor on the wpackagist site, but it was located within the linked github repo. 
I used `composer require wpackagist-plugin/classic-editor:1.6.3` in powershell and the plugin was added successfully, but please advise if this was improper protocol (since I wasn't sure if I should've done something like `composer require https://github.com/WordPress/classic-editor:1.6.3` instead).