### PR TITLE
Add Event-Tickets and Merged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /mysql/
 /themes/
+/html/

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "require": {
         "wpackagist-plugin/all-in-one-seo-pack": "4.3.*",
         "mt-support/tribe-ext-eventbrite-additional-options": "1.0.3",
-        "wpbakery/pagebuilder": "5.4.7"
+        "wpbakery/pagebuilder": "5.4.7",
+        "wpackagist-plugin/event-tickets": "5.5.10"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eab88abb38115077786c034c1d1ca859",
+    "content-hash": "469eb99d01a7e385f00fd450a0746fc1",
     "packages": [
         {
             "name": "composer/installers",
@@ -182,6 +182,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/all-in-one-seo-pack/"
+        },
+        {
+            "name": "wpackagist-plugin/event-tickets",
+            "version": "5.5.10",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/event-tickets/",
+                "reference": "tags/5.5.10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/event-tickets.5.5.10.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/event-tickets/"
         },
         {
             "name": "wpbakery/pagebuilder",


### PR DESCRIPTION
1. Event Tickets (Version 5.5.10)

* Merged with main branch by using sync fork due to being behind. Able to fix merge conflict by accepting combination locally. Tested localhost with docker desktop. All plugins in merge appeared on wordpress plugin tab.

* Unable to add Essential Grid (Version 2.2.4.1) due to website (https://account.essential-grid.com/licenses/pricing/) is subscription plugin and unable to search in ```composer search``` and in Wordpress Packagist (https://wpackagist.org/).

If there is any question feel free to ask.