### PR TITLE
Add Event-Tickets, Duplicate-Page, and Merge with Repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /mysql/
 /themes/
+/html/

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
         "wpackagist-plugin/real-media-library-lite": "4.19.0",
         "wpackagist-plugin/advanced-cron-manager": "2.5.0",
         "wpackagist-plugin/advanced-database-cleaner": "3.1.2",
-        "wpackagist-plugin/event-tickets": "5.5.10"
+        "wpackagist-plugin/event-tickets": "5.5.10",
+        "wpackagist-plugin/duplicate-page": "4.5.2"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,8 @@
         "wpackagist-plugin/real-media-library-lite": "4.19.0",
         "wpackagist-plugin/advanced-cron-manager": "2.5.0",
         "wpackagist-plugin/advanced-database-cleaner": "3.1.2",
+        "wpackagist-plugin/breeze": "2.0.20",
+        "wpackagist-plugin/classic-editor": "1.6.3",
         "wpackagist-plugin/event-tickets": "5.5.10",
         "wpackagist-plugin/duplicate-page": "4.5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
     "require": {
         "wpackagist-plugin/all-in-one-seo-pack": "4.3.*",
         "mt-support/tribe-ext-eventbrite-additional-options": "1.0.3",
-        "wpbakery/pagebuilder": "5.4.7"
+        "wpbakery/pagebuilder": "5.4.7",
+        "wpackagist-plugin/event-tickets": "5.5.10"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "024ace79ec6e37c7f94b805971b976ee",
+    "content-hash": "6909ef0d1cd0770d61baf452d81a0c6a",
     "packages": [
         {
             "name": "composer/installers",
@@ -218,6 +218,42 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/all-in-one-seo-pack/"
+        },
+        {
+            "name": "wpackagist-plugin/breeze",
+            "version": "2.0.20",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/breeze/",
+                "reference": "tags/2.0.20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/breeze.2.0.20.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/breeze/"
+        },
+        {
+            "name": "wpackagist-plugin/classic-editor",
+            "version": "1.6.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/classic-editor/",
+                "reference": "tags/1.6.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/classic-editor.1.6.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/classic-editor/"
         },
         {
             "name": "wpackagist-plugin/duplicate-page",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eab88abb38115077786c034c1d1ca859",
+    "content-hash": "024ace79ec6e37c7f94b805971b976ee",
     "packages": [
         {
             "name": "composer/installers",
@@ -220,22 +220,22 @@
             "homepage": "https://wordpress.org/plugins/all-in-one-seo-pack/"
         },
         {
-            "name": "wpackagist-plugin/real-media-library-lite",
-            "version": "4.19.0",
+            "name": "wpackagist-plugin/duplicate-page",
+            "version": "4.5.2",
             "source": {
                 "type": "svn",
-                "url": "https://plugins.svn.wordpress.org/real-media-library-lite/",
-                "reference": "tags/4.19.0"
+                "url": "https://plugins.svn.wordpress.org/duplicate-page/",
+                "reference": "trunk"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/real-media-library-lite.4.19.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/duplicate-page.zip?timestamp=1683202842"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
             },
             "type": "wordpress-plugin",
-            "homepage": "https://wordpress.org/plugins/real-media-library-lite/"
+            "homepage": "https://wordpress.org/plugins/duplicate-page/"
         },
         {
             "name": "wpackagist-plugin/event-tickets",
@@ -254,6 +254,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/event-tickets/"
+        },
+        {
+            "name": "wpackagist-plugin/real-media-library-lite",
+            "version": "4.19.0",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/real-media-library-lite/",
+                "reference": "tags/4.19.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/real-media-library-lite.4.19.0.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/real-media-library-lite/"
         },
         {
             "name": "wpbakery/pagebuilder",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eab88abb38115077786c034c1d1ca859",
+    "content-hash": "469eb99d01a7e385f00fd450a0746fc1",
     "packages": [
         {
             "name": "composer/installers",
@@ -182,6 +182,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/all-in-one-seo-pack/"
+        },
+        {
+            "name": "wpackagist-plugin/event-tickets",
+            "version": "5.5.10",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/event-tickets/",
+                "reference": "tags/5.5.10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/event-tickets.5.5.10.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/event-tickets/"
         },
         {
             "name": "wpbakery/pagebuilder",


### PR DESCRIPTION
1. Event Tickets (Version 5.5.10)

2. Duplicate Page (Version 4.5.2)

* Merged with main branch by using sync fork due to being behind. Able to fix merge conflict by accepting combination locally. Tested localhost with docker desktop. All plugins in merge appeared on wordpress plugin tab.

* Unable to add Essential Grid (Version 2.2.4.1) due to website (https://account.essential-grid.com/licenses/pricing/) is subscription plugin and unable to search in composer search and in Wordpress Packagist (https://wpackagist.org/).

* Unable to find Duplicate Page (Version 4.5.1) on Wordpress Packagist (https://wpackagist.org/) however did find (version 4.5.2). 

Removed ```tko-website``` folder from previous pull request and merged with updated repository.

If there is any question feel free to ask.