### PR TITLE
Add two plugins to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,9 @@
         "wpackagist-plugin/breeze": "2.0.20",
         "wpackagist-plugin/classic-editor": "1.6.3",
         "wpackagist-plugin/event-tickets": "5.5.10",
-        "wpackagist-plugin/duplicate-page": "4.5.2"
+        "wpackagist-plugin/duplicate-page": "4.5.2",
+        "wpackagist-plugin/mailchimp-for-wp": "4.9.3",
+        "wpackagist-plugin/wicked-folders": "2.18.17"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6909ef0d1cd0770d61baf452d81a0c6a",
+    "content-hash": "18de6962226ed8abb4816c3920312598",
     "packages": [
         {
             "name": "composer/installers",
@@ -292,6 +292,24 @@
             "homepage": "https://wordpress.org/plugins/event-tickets/"
         },
         {
+            "name": "wpackagist-plugin/mailchimp-for-wp",
+            "version": "4.9.3",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/mailchimp-for-wp/",
+                "reference": "tags/4.9.3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/mailchimp-for-wp.4.9.3.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/mailchimp-for-wp/"
+        },
+        {
             "name": "wpackagist-plugin/real-media-library-lite",
             "version": "4.19.0",
             "source": {
@@ -308,6 +326,24 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/real-media-library-lite/"
+        },
+        {
+            "name": "wpackagist-plugin/wicked-folders",
+            "version": "2.18.17",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wicked-folders/",
+                "reference": "tags/2.18.17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wicked-folders.2.18.17.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wicked-folders/"
         },
         {
             "name": "wpbakery/pagebuilder",


### PR DESCRIPTION
This is for issue #3. Added the MC4WP and Wicked Folders plugins to the composer. Plugins show up on the plugin page of wp-admin.

![image](https://github.com/trailkeepersoforegon/tko-website/assets/100104319/fbaa0daa-8b05-4029-9cd3-06b41de8f688)
