### PR TITLE
Added 2 additional packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,9 @@
         "wpackagist-plugin/redirection": "5.3.10",
         "wpackagist-plugin/redux-framework": "4.4.0",
         "wpackagist-plugin/multiple-admin-email-addresses": "1.1.2",
-        "wpackagist-plugin/disable-xml-rpc": "1.0.1"
+        "wpackagist-plugin/disable-xml-rpc": "1.0.1",
+        "wpackagist-plugin/wp-crontrol": "1.15.2",
+        "wpackagist-plugin/wp-shopify": "1.4.1"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2dde4e3b32d8f77afc2246b705ea7e0",
+    "content-hash": "972bb43b9b5ae73b73113cc1ae0fc7fe",
     "packages": [
         {
             "name": "composer/installers",
@@ -416,6 +416,42 @@
             },
             "type": "wordpress-plugin",
             "homepage": "https://wordpress.org/plugins/wicked-folders/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-crontrol",
+            "version": "1.15.2",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-crontrol/",
+                "reference": "tags/1.15.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-crontrol.1.15.2.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-crontrol/"
+        },
+        {
+            "name": "wpackagist-plugin/wp-shopify",
+            "version": "1.4.1",
+            "source": {
+                "type": "svn",
+                "url": "https://plugins.svn.wordpress.org/wp-shopify/",
+                "reference": "tags/1.4.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://downloads.wordpress.org/plugin/wp-shopify.1.4.1.zip"
+            },
+            "require": {
+                "composer/installers": "^1.0 || ^2.0"
+            },
+            "type": "wordpress-plugin",
+            "homepage": "https://wordpress.org/plugins/wp-shopify/"
         },
         {
             "name": "wpbakery/pagebuilder",


### PR DESCRIPTION
Successfully integrated the following 2 packages:
"wpackagist-plugin/wp-crontrol": "1.15.2",
"wpackagist-plugin/wp-shopify": "1.4.1"

Verified on plugins page at http://localhost:8000/wp-admin